### PR TITLE
Fix negative number formatting

### DIFF
--- a/js/mainpage.js
+++ b/js/mainpage.js
@@ -92,12 +92,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (value === null || value === undefined || value === '') {
       return '';
     }
-    const cleanNumString = String(value).replace(/[^0-9.]/g, '');
+    // Preserve negative values by keeping the minus sign
+    const cleanNumString = String(value).replace(/[^0-9.-]/g, '');
     const num = parseFloat(cleanNumString);
     if (isNaN(num)) {
       return '';
     }
-    return `$${num.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
+    const absVal = Math.abs(num).toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return (num < 0 ? '-$' : '$') + absVal;
   }
 
   // Parses a formatted currency string back to a number
@@ -115,7 +117,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (value === null || value === undefined || value === '') {
       return '';
     }
-    const num = parseFloat(String(value).replace(/[^0-9.]/g, ''));
+    // Allow negative percentages by retaining the minus sign
+    const num = parseFloat(String(value).replace(/[^0-9.-]/g, ''));
     if (isNaN(num)) {
       return '';
     }


### PR DESCRIPTION
## Summary
- handle negatives in currency and percentage display helpers

## Testing
- `node --check js/mainpage.js`

------
https://chatgpt.com/codex/tasks/task_e_684b270d0478832785e2972032638b33